### PR TITLE
Remove force backtrace of exceptions

### DIFF
--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -635,7 +635,6 @@ impl<'js> Ctx<'js> {
             if let Some(x) = (*self.get_opaque()).panic.take() {
                 panic::resume_unwind(x)
             }
-            println!("{}", std::backtrace::Backtrace::force_capture());
             Err(Error::Exception)
         }
     }


### PR DESCRIPTION
Backtraces should not always show as soon as we hit an exception in JS-land.